### PR TITLE
Feature/depth override

### DIFF
--- a/src/components/canvas/SceneContent.jsx
+++ b/src/components/canvas/SceneContent.jsx
@@ -507,7 +507,7 @@ const SceneContent = () => {
       <Lights />
       {/* Camera */}
       <animated.group position={camSpring.position} rotation={camSpring.rotation}>
-        <PerspectiveCamera makeDefault fov={90} ref={cameraRef} near={0.1} far={20}>
+        <PerspectiveCamera makeDefault fov={90} ref={cameraRef} near={0.1} far={50}>
           {/* UI */}
           {ko === 'STOP' ? (
             <FinalStatusUI stats={score.current} />
@@ -560,7 +560,7 @@ const SceneContent = () => {
           />
         )
       })}
-      <primitive object={tent} position={[0, -3, 0]} scale={(0.5, 0.5, 0.5)} material={tentMaterial} />
+      <primitive object={tent} position={[0, -3, 0]} scale={(0.5, 0.5, 0.5)} material={tentMaterial} renderOrder={-1} />
     </group>
   )
 }

--- a/src/helpers/materials.js
+++ b/src/helpers/materials.js
@@ -29,6 +29,7 @@ const tentMaterial = new CustomRays({
   color2: new Color(0.1, 0, 0.1),
   rays: 32,
   side: BackSide,
+  depthTest: false,
 })
 
 export { levelMaterial, gloveMaterial, floorMaterial, testMaterial, tentMaterial }


### PR DESCRIPTION
force background mesh to always be rendered first, behind every other draw